### PR TITLE
Add `Education`, `Work Experience` and `Projects` form fields.

### DIFF
--- a/components/header/index.js
+++ b/components/header/index.js
@@ -20,7 +20,7 @@ const Header = () => {
             return (
                 <div className="flex items-center space-x-6">
                     <button
-                        className="text-gray-600 hover:text-gray-800"
+                        className="text-gray-600 font-semibold hover:text-gray-800"
                         type="button"
                         href="/api/auth/signin"
                         onClick={onSignInClick}
@@ -28,7 +28,7 @@ const Header = () => {
                         Sign in
                     </button>
                     <button
-                        className="rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
+                        className="rounded-full font-semibold border border-gray-300 bg-white px-4 py-2 text-sm text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
                         type="button"
                         onClick={onSignInClick}
                     >

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,7 +34,7 @@ const Home = () => {
                         est.
                     </p>
                     <button
-                        className="rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
+                        className="rounded-full font-semibold border border-gray-300 bg-white px-4 py-2 text-sm text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
                         type="button"
                     >
                         Get Started

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -188,148 +188,199 @@ const Profile = () => {
                         </div>
                     </div>
                     <div className="flex flex-col flex-grow basis-5/12 items-start gap-3">
-                        <h2 className="text-2xl font-semibold"> Contact </h2>
-
-                        <div className="flex w-full flex-row items-center justify-between">
-                            <label
-                                className="w-28 font-medium text-gray-900"
-                                for="phone"
-                            >
-                                {' '}
-                                Phone{' '}
-                            </label>
-                            <input
-                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                type="text"
-                                id="phone"
-                                name="phone"
-                            />
-                        </div>
-                        <h3 className="text-lg font-semibold"> Location </h3>
+                        <h2 className="text-2xl font-semibold"> Education </h2>
                         <div className="flex w-full flex-row items-center justify-between">
                             <label
                                 className="font-medium text-gray-900"
-                                for="country"
+                                for="school"
                             >
                                 {' '}
-                                Country{' '}
+                                School{' '}
                             </label>
                             <input
                                 className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
                                 type="text"
-                                id="country"
-                                name="country"
+                                id="school"
+                                name="school"
                             />{' '}
                         </div>
                         <div className="flex w-full flex-row items-center justify-between">
                             <label
                                 className="w-28 font-medium text-gray-900"
-                                for="city"
+                                for="course"
                             >
                                 {' '}
-                                City{' '}
+                                Course{' '}
                             </label>
                             <input
                                 className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
                                 type="text"
-                                id="city"
-                                name="city"
-                            />
-                        </div>
-                        <h3 className="text-lg font-semibold"> Socials </h3>
-                        <div className="flex w-full flex-row items-center justify-between">
-                            <label
-                                className="w-28 font-medium text-gray-900"
-                                for="linkedin"
-                            >
-                                {' '}
-                                LinkedIn{' '}
-                            </label>
-                            <input
-                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                type="text"
-                                id="linkedin"
-                                name="linkedin"
+                                id="course"
+                                name="course"
                             />
                         </div>
                         <div className="flex w-full flex-row items-center justify-between">
                             <label
                                 className="w-28 font-medium text-gray-900"
-                                for="twitter"
+                                for="from"
                             >
                                 {' '}
-                                Twitter{' '}
+                                Period{' '}
                             </label>
-                            <input
-                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                type="text"
-                                id="twitter"
-                                name="twitter"
-                            />
+                            <div className="flex flex-row gap-3 items-center w-2/3">
+                                <input
+                                    className="w-3/4 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                    type="month"
+                                    id="from"
+                                    name="from"
+                                />
+                                <div className="w-12 h-0.5 bg-gray-900"></div> {/* Gap between `from` and `to`, represents a 2-pixel high line. */}
+                                <input
+                                    className="w-3/4 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                    type="month"
+                                    id="to"
+                                    name="to"
+                                />
+                            </div>
                         </div>
-                        <div className="flex w-full flex-row items-center justify-between">
-                            <label
-                                className="w-28 font-medium text-gray-900"
-                                for="fb"
-                            >
-                                {' '}
-                                Facebook{' '}
-                            </label>
-                            <input
-                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                type="text"
-                                id="fb"
-                                name="fb"
-                            />
-                        </div>
+                        <button
+                            className="text-gray-600 font-semibold hover:text-gray-800"
+                            type="button"
+                        >
+                            + Add Education
+                        </button>
                     </div>
                     <div className="flex flex-col flex-grow basis-5/12 items-start gap-3">
-                        <h2 className="text-2xl font-semibold"> General </h2>
+                        <h2 className="text-2xl font-semibold"> Work Experience </h2>
                         <div className="flex w-full flex-row items-center justify-between">
                             <label
                                 className="font-medium text-gray-900"
-                                for="name"
+                                for="company"
                             >
                                 {' '}
-                                Full name{' '}
+                                Company{' '}
                             </label>
                             <input
                                 className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
                                 type="text"
-                                id="name"
-                                name="name"
+                                id="company"
+                                name="company"
                             />{' '}
                         </div>
                         <div className="flex w-full flex-row items-center justify-between">
                             <label
                                 className="w-28 font-medium text-gray-900"
-                                for="title"
+                                for="Location"
                             >
                                 {' '}
-                                Job title{' '}
+                                Location{' '}
                             </label>
                             <input
                                 className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
                                 type="text"
-                                id="title"
-                                name="title"
+                                id="course"
+                                name="course"
                             />
                         </div>
                         <div className="flex w-full flex-row items-center justify-between">
                             <label
                                 className="w-28 font-medium text-gray-900"
-                                for="about"
+                                for="from"
                             >
                                 {' '}
-                                About{' '}
+                                Period{' '}
+                            </label>
+                            <div className="flex flex-row gap-3 items-center w-2/3">
+                                <input
+                                    className="w-3/4 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                    type="month"
+                                    id="from"
+                                    name="from"
+                                />
+                                <div className="w-12 h-0.5 bg-gray-900"></div> {/* Gap between `from` and `to`, represents a 2-pixel high line. */}
+                                <input
+                                    className="w-3/4 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                    type="month"
+                                    id="to"
+                                    name="to"
+                                />
+                            </div>
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="description"
+                            >
+                                {' '}
+                                Description{' '}
                             </label>
                             <textarea
                                 className="w-2/3 appearance-none rounded-3xl border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
                                 rows={3}
-                                id="about"
-                                name="about"
+                                id="description"
+                                name="description"
                             />
                         </div>
+                        <button
+                            className="text-gray-600 font-semibold hover:text-gray-800"
+                            type="button"
+                        >
+                            + Add Work Experience
+                        </button>
+                    </div>
+                    <div className="flex flex-col flex-grow basis-5/12 items-start gap-3">
+                        <h2 className="text-2xl font-semibold"> Projects </h2>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="font-medium text-gray-900"
+                                for="project"
+                            >
+                                {' '}
+                                Name{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="project"
+                                name="project"
+                            />{' '}
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="font-medium text-gray-900"
+                                for="repo"
+                            >
+                                {' '}
+                                Repository{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="repo"
+                                name="repo"
+                            />{' '}
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="description"
+                            >
+                                {' '}
+                                Description{' '}
+                            </label>
+                            <textarea
+                                className="w-2/3 appearance-none rounded-3xl border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                rows={3}
+                                id="description"
+                                name="description"
+                            />
+                        </div>
+                        <button
+                            className="text-gray-600 font-semibold hover:text-gray-800"
+                            type="button"
+                        >
+                            + Add Project
+                        </button>
                     </div>
                 </form>
             </main>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -39,112 +39,296 @@ const Profile = () => {
                 </div>
 
                 <form
-                    className="flex w-full flex-col items-start gap-8"
+                    className="flex w-full flex-row flex-wrap items-start gap-x-40 gap-y-12"
                     action="/send-data-here"
                     method="post"
                 >
-                    <div className="flex w-full flex-row flex-wrap items-start gap-x-40 gap-y-8">
-                        <div className="flex w-full flex-grow basis-80 flex-col items-start gap-3">
-                            <h2 className="text-2xl font-semibold">
+                    <div className="flex flex-col flex-grow basis-5/12 items-start gap-3">
+                        <h2 className="text-2xl font-semibold"> General </h2>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="font-medium text-gray-900"
+                                for="name"
+                            >
                                 {' '}
-                                General{' '}
-                            </h2>
-                            <div className="flex w-full flex-row items-center justify-between">
-                                <label
-                                    className="font-medium text-gray-900"
-                                    for="name"
-                                >
-                                    {' '}
-                                    Full name{' '}
-                                </label>
-                                <input
-                                    className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                    type="text"
-                                    id="name"
-                                    name="name"
-                                />{' '}
-                            </div>
-                            <div className="flex w-full flex-row items-center justify-between">
-                                <label
-                                    className="w-28 font-medium text-gray-900"
-                                    for="title"
-                                >
-                                    {' '}
-                                    Job title{' '}
-                                </label>
-                                <input
-                                    className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                    type="text"
-                                    id="title"
-                                    name="title"
-                                />
-                            </div>
-                            <div className="flex w-full flex-row items-center justify-between">
-                                <label
-                                    className="w-28 font-medium text-gray-900"
-                                    for="about"
-                                >
-                                    {' '}
-                                    About{' '}
-                                </label>
-                                <textarea
-                                    className="w-2/3 appearance-none rounded-3xl border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                    rows={3}
-                                    id="about"
-                                    name="about"
-                                />
-                            </div>
+                                Full name{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="name"
+                                name="name"
+                            />{' '}
                         </div>
-                        <div className="flex w-full min-w-min flex-grow basis-80 flex-col items-start gap-3">
-                            <h2 className="text-2xl font-semibold">
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="title"
+                            >
                                 {' '}
-                                General{' '}
-                            </h2>
-                            <div className="flex w-full flex-row items-center justify-between">
-                                <label
-                                    className="font-medium text-gray-900"
-                                    for="name"
-                                >
-                                    {' '}
-                                    Full name{' '}
-                                </label>
-                                <input
-                                    className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                    type="text"
-                                    id="name"
-                                    name="name"
-                                />{' '}
-                            </div>
-                            <div className="flex w-full flex-row items-center justify-between">
-                                <label
-                                    className="w-28 font-medium text-gray-900"
-                                    for="title"
-                                >
-                                    {' '}
-                                    Job title{' '}
-                                </label>
-                                <input
-                                    className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                    type="text"
-                                    id="title"
-                                    name="title"
-                                />
-                            </div>
-                            <div className="flex w-full flex-row items-center justify-between">
-                                <label
-                                    className="w-28 font-medium text-gray-900"
-                                    for="about"
-                                >
-                                    {' '}
-                                    About{' '}
-                                </label>
-                                <textarea
-                                    className="w-2/3 appearance-none rounded-3xl border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                    rows={3}
-                                    id="about"
-                                    name="about"
-                                />
-                            </div>
+                                Job title{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="title"
+                                name="title"
+                            />
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="about"
+                            >
+                                {' '}
+                                About{' '}
+                            </label>
+                            <textarea
+                                className="w-2/3 appearance-none rounded-3xl border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                rows={3}
+                                id="about"
+                                name="about"
+                            />
+                        </div>
+                    </div>
+                    <div className="flex flex-col flex-grow basis-5/12 items-start gap-3">
+                        <h2 className="text-2xl font-semibold"> Contact </h2>
+
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="phone"
+                            >
+                                {' '}
+                                Phone{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="phone"
+                                name="phone"
+                            />
+                        </div>
+                        <h3 className="text-lg font-semibold"> Location </h3>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="font-medium text-gray-900"
+                                for="country"
+                            >
+                                {' '}
+                                Country{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="country"
+                                name="country"
+                            />{' '}
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="city"
+                            >
+                                {' '}
+                                City{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="city"
+                                name="city"
+                            />
+                        </div>
+                        <h3 className="text-lg font-semibold"> Socials </h3>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="linkedin"
+                            >
+                                {' '}
+                                LinkedIn{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="linkedin"
+                                name="linkedin"
+                            />
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="twitter"
+                            >
+                                {' '}
+                                Twitter{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="twitter"
+                                name="twitter"
+                            />
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="fb"
+                            >
+                                {' '}
+                                Facebook{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="fb"
+                                name="fb"
+                            />
+                        </div>
+                    </div>
+                    <div className="flex flex-col flex-grow basis-5/12 items-start gap-3">
+                        <h2 className="text-2xl font-semibold"> Contact </h2>
+
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="phone"
+                            >
+                                {' '}
+                                Phone{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="phone"
+                                name="phone"
+                            />
+                        </div>
+                        <h3 className="text-lg font-semibold"> Location </h3>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="font-medium text-gray-900"
+                                for="country"
+                            >
+                                {' '}
+                                Country{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="country"
+                                name="country"
+                            />{' '}
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="city"
+                            >
+                                {' '}
+                                City{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="city"
+                                name="city"
+                            />
+                        </div>
+                        <h3 className="text-lg font-semibold"> Socials </h3>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="linkedin"
+                            >
+                                {' '}
+                                LinkedIn{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="linkedin"
+                                name="linkedin"
+                            />
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="twitter"
+                            >
+                                {' '}
+                                Twitter{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="twitter"
+                                name="twitter"
+                            />
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="fb"
+                            >
+                                {' '}
+                                Facebook{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="fb"
+                                name="fb"
+                            />
+                        </div>
+                    </div>
+                    <div className="flex flex-col flex-grow basis-5/12 items-start gap-3">
+                        <h2 className="text-2xl font-semibold"> General </h2>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="font-medium text-gray-900"
+                                for="name"
+                            >
+                                {' '}
+                                Full name{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="name"
+                                name="name"
+                            />{' '}
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="title"
+                            >
+                                {' '}
+                                Job title{' '}
+                            </label>
+                            <input
+                                className="w-2/3 appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                type="text"
+                                id="title"
+                                name="title"
+                            />
+                        </div>
+                        <div className="flex w-full flex-row items-center justify-between">
+                            <label
+                                className="w-28 font-medium text-gray-900"
+                                for="about"
+                            >
+                                {' '}
+                                About{' '}
+                            </label>
+                            <textarea
+                                className="w-2/3 appearance-none rounded-3xl border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                rows={3}
+                                id="about"
+                                name="about"
+                            />
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
# Overview

Add the `Education`, `Work Experience` and `Projects` form fields to the profile page.

## Features

>**Note:**
   The `Add [Category]`-buttons do not currently function.

## Issues

- #6 
   > Some  `id`s and `name`s of `input`s are identical. This is currently the case because there will be several sub-categories for `Education` and `Work Experience` - the `id` naming scheme still has to be hashed out.
- #7
   > Form categories appear to have inconsistent spacing on desktop (`1072 px` or more).
- #8
   > The `Education` and `Work Experience` form categories overflow the screen if the page is viewed on bile (`695 px` or less).

# Related documentation

## Screenshots

**Desktop:**

![image](https://user-images.githubusercontent.com/14112766/171939135-2d4e890f-6dff-4a0a-8f26-0f4deddd0546.png)
