### PR TITLE
Adjust styling of profile-page and sign-out section.

### DIFF
--- a/components/layout/header/index.js
+++ b/components/layout/header/index.js
@@ -50,10 +50,10 @@ const Header = () => {
                             className="text-xs text-gray-600 hover:text-gray-800"
                             onClick={onSignOutClick}
                         >
-                            Sign out
+                            Sign Out
                         </a>
                     </Link>
-                    <div className="h-full rounded-full ring-2 ring-indigo-500 ring-offset-2">
+                    <div className="h-7 rounded-full ring-2 ring-indigo-500 ring-offset-2">
                         <Image
                             className="h-full aspect-square"
                             src={session.user.image}

--- a/components/layout/header/index.js
+++ b/components/layout/header/index.js
@@ -21,7 +21,7 @@ const Header = () => {
                             type="button"
                             href="/signin"
                         >
-                            Sign in
+                            Sign In
                         </button>
                     </Link>
                     <Link href="/signin">
@@ -38,16 +38,8 @@ const Header = () => {
 
         if (session?.user) {
             return (
-                <div className="flex items-center space-x-3">
-                    <div className="rounded-full bg-indigo-500 ring-2 ring-indigo-500 ring-offset-2 ring-offset-white">
-                        <Image
-                            className="h-8 w-8"
-                            src={session.user.image}
-                            alt=""
-                            style={{ borderRadius: '100%' }}
-                        />
-                    </div>
-                    <p className="hidden sm:inline">
+                <div className="flex items-center gap-3">
+                    <p className="text-sm hidden sm:inline">
                         Hi,{' '}
                         <span className="font-semibold">
                             {session.user.name}
@@ -61,13 +53,21 @@ const Header = () => {
                             Sign out
                         </a>
                     </Link>
+                    <div className="h-full rounded-full ring-2 ring-indigo-500 ring-offset-2">
+                        <Image
+                            className="h-full aspect-square"
+                            src={session.user.image}
+                            alt=""
+                            style={{ borderRadius: '100%' }}
+                        />
+                    </div>
                 </div>
             );
         }
     };
 
     return (
-        <nav className="flex w-full flex-row justify-between bg-white px-8 py-5">
+        <nav className="flex w-full h-16 flex-row justify-between bg-white px-8 py-5">
             <div className="flex items-center space-x-3">
                 <Image
                     className="h-7"

--- a/features/profile/profile-form/index.js
+++ b/features/profile/profile-form/index.js
@@ -1,5 +1,4 @@
 import { Form, Formik } from 'formik';
-
 import ProfileFormSection from './profile-form-section';
 import { profileFormSchema } from '../../../constants/profile-form-schema';
 import profileFormTemplate from '../../../constants/profile-form-template';
@@ -17,7 +16,7 @@ const ProfileForm = () => {
             validationSchema={profileFormSchema}
         >
             {({ values }) => (
-                <Form id="form" className="flex w-full flex-row flex-wrap items-start gap-x-40 gap-y-12">
+                <Form id="form" className="grid grid-flow-row w-full gap-x-40 gap-y-12 lg:grid-cols-2 lg:grid-flow-row-dense">
                     {profileFormTemplate.map(section => (
                         <ProfileFormSection
                             defaultValues={values}

--- a/features/profile/profile-form/index.js
+++ b/features/profile/profile-form/index.js
@@ -17,7 +17,7 @@ const ProfileForm = () => {
             validationSchema={profileFormSchema}
         >
             {({ values }) => (
-                <Form className="flex w-full flex-row flex-wrap items-start gap-x-40 gap-y-12">
+                <Form id="form" className="flex w-full flex-row flex-wrap items-start gap-x-40 gap-y-12">
                     {profileFormTemplate.map(section => (
                         <ProfileFormSection
                             defaultValues={values}
@@ -25,12 +25,6 @@ const ProfileForm = () => {
                             {...section}
                         />
                     ))}
-                    <button
-                        className="rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
-                        type="submit"
-                    >
-                        Save changes
-                    </button>
                 </Form>
             )}
         </Formik>

--- a/features/profile/profile-form/profile-form-field/index.js
+++ b/features/profile/profile-form/profile-form-field/index.js
@@ -36,34 +36,33 @@ const ProfileFormField = ({ label, name, type }) => {
                         Period
                     </label>
                     <div className="flex w-2/3 flex-row flex-wrap items-center gap-3">
-                        <div className="flex items-center gap-5 flex-grow basis-5/12">
-                            <p className="w-12"> From </p>
-                            <div className="w-full space-y-1">
-                                <Field
-                                    className="w-full appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                    name={`${name}.from`}
-                                    type="month"
-                                />
-                                <ErrorMessage
-                                    name={`${name}.from`}
-                                    className="text-xs text-red-600"
-                                    component="div"
-                                />
-                            </div>
-                        </div>
-                        <div className="flex items-center gap-5 flex-grow basis-5/12">
-                            <p className="w-12"> To </p>
-                            <div className="w-full space-y-1">
-                                <Field
-                                    className="w-full appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
-                                    name={`${name}.to`}
-                                    type="month"
-                                />
-                                <ErrorMessage
-                                    name={`${name}.to`}
-                                    className="text-xs text-red-600"
-                                    component="div"
-                                />
+                        <div className="flex flex-row items-center gap-3 w-full">
+                            <p className="text-xs"> To </p>
+                            <div className="flex flex-col gap-2 w-full">
+                                <div className="w-full space-y-1">
+                                    <Field
+                                        className="w-full appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                        name={`${name}.from`}
+                                        type="month"
+                                    />
+                                    <ErrorMessage
+                                        name={`${name}.from`}
+                                        className="text-xs text-red-600"
+                                        component="div"
+                                    />
+                                </div>
+                                <div className="w-full space-y-1">
+                                    <Field
+                                        className="w-full appearance-none rounded-full border-2 border-gray-500 bg-transparent px-4 py-2 font-medium text-gray-500 focus:text-gray-900"
+                                        name={`${name}.to`}
+                                        type="month"
+                                    />
+                                    <ErrorMessage
+                                        name={`${name}.to`}
+                                        className="text-xs text-red-600"
+                                        component="div"
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/features/profile/profile-form/profile-form-section/index.js
+++ b/features/profile/profile-form/profile-form-section/index.js
@@ -7,7 +7,7 @@ const ProfileFormSection = ({
     onAddItemButtonClick,
     onRemoveItemButtonClick
 }) => (
-    <div className="flex flex-grow basis-5/12 flex-col items-start gap-3">
+    <div className="flex flex-col items-start gap-3">
         <h2 className="text-2xl font-semibold">{label}</h2>
         {fields.map(field => {
             const values = field.isMutable

--- a/features/profile/profile-form/profile-form-subsection/index.js
+++ b/features/profile/profile-form/profile-form-subsection/index.js
@@ -63,7 +63,7 @@ const ProfileFormSubsection = ({
                                     </Fragment>
                                 ))}
                             <button
-                                className="font-semibold text-gray-600 hover:text-gray-800"
+                                className="rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
                                 onClick={() => push(emptyItem)}
                                 type="button"
                             >

--- a/features/profile/profile-form/profile-form-subsection/index.js
+++ b/features/profile/profile-form/profile-form-subsection/index.js
@@ -53,7 +53,7 @@ const ProfileFormSubsection = ({
                                         ))}
                                         {defaultValues.length > 1 && (
                                             <button
-                                                className="font-semibold text-gray-600 hover:text-gray-800"
+                                                className="font-semibold text-red-400 hover:text-red-600"
                                                 onClick={() => remove(index)}
                                                 type="button"
                                             >

--- a/features/profile/profile-hero/index.js
+++ b/features/profile/profile-hero/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from '../../../components/image';
 import { useSession } from 'next-auth/react';
 
 const ProfileHero = () => {
@@ -6,7 +7,12 @@ const ProfileHero = () => {
 
     return (
         <div className="flex w-full flex-row items-center gap-8">
-            <div className="h-32 aspect-square rounded-full bg-gray-900">  </div>
+            <Image
+                className="h-32 aspect-square"
+                src={session.user.image}
+                alt=""
+                style={{ borderRadius: '100%' }}
+            />
             <div className="flex w-full flex-col items-start gap-4">
                 <h1 className="text-4xl font-bold">
                     <span className="text-indigo-500">

--- a/features/profile/profile-hero/index.js
+++ b/features/profile/profile-hero/index.js
@@ -6,22 +6,40 @@ const ProfileHero = () => {
     const { data: session } = useSession();
 
     return (
-        <div className="flex w-full flex-row items-center gap-8">
-            <Image
-                className="h-32 aspect-square"
-                src={session.user.image}
-                alt=""
-                style={{ borderRadius: '100%' }}
-            />
-            <div className="flex w-full flex-col items-start gap-4">
-                <h1 className="text-4xl font-bold">
-                    <span className="text-indigo-500">
-                        {session?.user?.name}
-                    </span>
-                    <br />
-                    <span className="text">Software Engineer</span>
-                </h1>
-                <p className="text-gray-500">{session.user.email}</p>
+        <div className="flex flex-row flex-wrap items-center justify-between w-full gap-10"> 
+            <div className="flex flex-row items-center flex-grow gap-8">
+                <Image
+                    className="h-32 aspect-square"
+                    src={session.user.image}
+                    alt=""
+                    style={{ borderRadius: '100%' }}
+                />
+                <div className="flex w-full flex-col items-start gap-4">
+                    <h1 className="text-4xl font-bold">
+                        <span className="text-indigo-500">
+                            {session?.user?.name}
+                        </span>
+                        <br />
+                        <span className="text">Software Engineer</span>
+                    </h1>
+                    <p className="text-gray-500">{session.user.email}</p>
+                </div>
+            </div>
+
+            <div className="flex gap-3 w-fit">
+                <button
+                    className="rounded-full border border-gray-300 px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:bg-indigo-500 dark:text-white dark:hover:bg-indigo-400 dark:focus:ring-gray-700"
+                    type="submit"
+                    form="form"
+                >
+                    Save Changes
+                </button>
+                <button
+                    className="rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
+                    type="button"
+                >
+                    View Portfolio
+                </button>
             </div>
         </div>
     );

--- a/features/profile/profile-hero/index.js
+++ b/features/profile/profile-hero/index.js
@@ -9,7 +9,7 @@ const ProfileHero = () => {
         <div className="flex flex-row flex-wrap items-center justify-between w-full gap-10"> 
             <div className="flex flex-row items-center flex-grow gap-8">
                 <Image
-                    className="h-32 aspect-square"
+                    className="h-32 aspect-square hidden sm:inline"
                     src={session.user.image}
                     alt=""
                     style={{ borderRadius: '100%' }}

--- a/features/profile/profile-hero/index.js
+++ b/features/profile/profile-hero/index.js
@@ -5,7 +5,8 @@ const ProfileHero = () => {
     const { data: session } = useSession();
 
     return (
-        <div className="flex w-full flex-row gap-8">
+        <div className="flex w-full flex-row items-center gap-8">
+            <div className="h-32 aspect-square rounded-full bg-gray-900">  </div>
             <div className="flex w-full flex-col items-start gap-4">
                 <h1 className="text-4xl font-bold">
                     <span className="text-indigo-500">


### PR DESCRIPTION
# Overview

Adjust the styling of the profile page and `nav` sign-out section to closer match Figma design.

## Features

- Ensure `nav` component's height stays the same, regardless of whether the user is signed in or not.
- Make `Add [Category]`-buttons more prominent.
- Separate out `Save Changes`/`submit`-button from `Form` component to the profile hero component.

>**Notes:**
   `View Portfolio`-button not yet functional.
   Unsure whether `Save Changes`-button is functional.

# Related documentation

## Screenshots

![image](https://user-images.githubusercontent.com/14112766/172066925-3d45b2e7-ed2f-45b3-8f0d-057787da1c79.png)